### PR TITLE
Fix program name in CLI help

### DIFF
--- a/transplant
+++ b/transplant
@@ -15,7 +15,7 @@ SUMMARY_RE = re.compile(r"^\d+\s+(?:directories?|files?)", re.I)
 
 def parse_args(args):
     argp = argparse.ArgumentParser(
-        prog=__name__,
+        prog="transplant",
         description=__doc__,
     )
 


### PR DESCRIPTION
## Summary
- update ArgumentParser to use `prog="transplant"`

## Testing
- `python3 transplant --help`


------
https://chatgpt.com/codex/tasks/task_e_684044b4e39083288e79e0d7e13f2966