### PR TITLE
Remove unused os import

### DIFF
--- a/transplant
+++ b/transplant
@@ -4,7 +4,6 @@
 
 import argparse
 from pathlib import Path
-import os
 import re
 import sys
 


### PR DESCRIPTION
## Summary
- remove unused `os` import from `transplant`

## Testing
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_684044b3bafc8328b3a56fef19c90ae8