### PR TITLE
Handle trailing slashes from tree -F

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,12 @@ Where:
 
 ## Examples
 
-1. Generate a tree representation of a directory structure:
+1. Generate a tree representation of a directory structure. Use `tree -F` (or
+   `tree --slash-indicators` on newer versions) so that directories end with a
+   trailing `/`:
 
 ```bash
-tree /path/to/source > directory_structure.txt
+tree -F /path/to/source > directory_structure.txt
 ```
 
 2. Recreate that structure in a new location:

--- a/transplant
+++ b/transplant
@@ -8,7 +8,9 @@ import re
 import sys
 
 
-LINE_RE = re.compile(r"^(?P<prefix>(?:│   |    )*)(?P<fork>[├└])── (?P<name>.+)$")
+LINE_RE = re.compile(
+    r"^(?P<prefix>(?:│   |    )*)(?P<fork>[├└])── (?P<name>.+?)(?P<is_dir>/)?$"
+)
 SUMMARY_RE = re.compile(r"^\d+\s+(?:directories?|files?)", re.I)
 
 
@@ -56,7 +58,9 @@ def parse_args(args):
     return parsed
 
 
-def is_probably_file(fname):
+def is_probably_file(fname, is_dir=None):
+    if is_dir is not None:
+        return not is_dir
     return "." in fname.strip(".") and not fname.endswith("/")
 
 
@@ -91,8 +95,9 @@ def rebuild_tree(listing_path, destination, dry_run=False, verbose=False):
 
             depth = len(m.group("prefix")) // 4 + 1
             name = m.group("name").rstrip("/")
+            is_dir = True if m.group("is_dir") else None
             if verbose:
-                print(f"Depth: {depth}, Name: {name}")
+                print(f"Depth: {depth}, Name: {name}, Dir: {is_dir}")
 
             stack = stack[:depth]
             parent_dir = stack[-1]
@@ -101,7 +106,7 @@ def rebuild_tree(listing_path, destination, dry_run=False, verbose=False):
                 print(f"parent: {parent_dir}")
                 print(f"CREATE {target}")
 
-            if is_probably_file(name):
+            if is_probably_file(name, is_dir=is_dir):
                 if not dry_run:
                     target.parent.mkdir(parents=True, exist_ok=True)
                     target.touch(exist_ok=True)


### PR DESCRIPTION
## Summary
- document using `tree -F` (or `--slash-indicators`) when creating a listing
- parse optional trailing `/` in directory listings
- create files or directories based on the slash indicator

## Testing
- `python -m py_compile transplant`
- `python transplant sample.tree /tmp/dest_test --verbose`
- `python transplant test_slash.tree /tmp/test_slash_dest --verbose`

------
https://chatgpt.com/codex/tasks/task_e_6842022ac9208328b294786ee3857daf