### PR TITLE
Add ASCII parsing option to transplant

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Where:
 ```
 -d, --dry-run   Don't touch the filesystem—just report what would be done
 -v, --verbose   Print each path as it is (or would be) created
+    --ascii     Parse ASCII tree output instead of Unicode
 -h, --help      Show help message and exit
 ```
 

--- a/transplant
+++ b/transplant
@@ -8,7 +8,12 @@ import re
 import sys
 
 
-LINE_RE = re.compile(r"^(?P<prefix>(?:│   |    )*)(?P<fork>[├└])── (?P<name>.+)$")
+UNICODE_LINE_RE = re.compile(
+    r"^(?P<prefix>(?:│   |    )*)(?P<fork>[├└])── (?P<name>.+)$"
+)
+ASCII_LINE_RE = re.compile(
+    r"^(?P<prefix>(?:\|   |    )*)(?P<fork>[\|+`\\])-- (?P<name>.+)$"
+)
 SUMMARY_RE = re.compile(r"^\d+\s+(?:directories?|files?)", re.I)
 
 
@@ -47,6 +52,12 @@ def parse_args(args):
         help="Print each path as it is (or would be) created.",
     )
 
+    argp.add_argument(
+        "--ascii",
+        action="store_true",
+        help="Parse ASCII tree output instead of Unicode.",
+    )
+
     parsed = argp.parse_args(args)
     if not parsed.dry_run and parsed.destination is None:
         argp.error(
@@ -60,7 +71,7 @@ def is_probably_file(fname):
     return "." in fname.strip(".") and not fname.endswith("/")
 
 
-def rebuild_tree(listing_path, destination, dry_run=False, verbose=False):
+def rebuild_tree(listing_path, destination, dry_run=False, verbose=False, ascii=False):
     if not listing_path.exists():
         sys.exit(f"Listing file not found: {listing_path}")
 
@@ -74,6 +85,8 @@ def rebuild_tree(listing_path, destination, dry_run=False, verbose=False):
 
     stack = [destination]
 
+    line_re = ASCII_LINE_RE if ascii else UNICODE_LINE_RE
+
     with listing_path.open("r", encoding="utf-8") as fh:
         for raw in fh:
             line = raw.rstrip("\n")
@@ -83,7 +96,7 @@ def rebuild_tree(listing_path, destination, dry_run=False, verbose=False):
             if line.strip() == "." or SUMMARY_RE.match(line):
                 continue
 
-            m = LINE_RE.match(line)
+            m = line_re.match(line)
             if not m:
                 if verbose:
                     print("failed to match line format, skipping...")
@@ -121,6 +134,7 @@ def main(args):
         destination=params.destination,
         dry_run=params.dry_run,
         verbose=params.verbose,
+        ascii=params.ascii,
     )
 
 


### PR DESCRIPTION
## Summary
- support ASCII formatted tree listings with a new `--ascii` flag
- compile regex for ASCII or Unicode output as needed
- document the new flag in the README

## Testing
- `python3 -m py_compile transplant`
- `python3 transplant --help`

------
https://chatgpt.com/codex/tasks/task_e_68420229b1b883289a4b7983d5ae31b8