### PR TITLE
Add version flag, stdin support and force option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Basic usage:
 ```
 
 Where:
-- `TREE_OUTPUT` is a text file containing the output of the `tree` command
+- `TREE_OUTPUT` is a text file containing the output of the `tree` command. Use
+  `-` to read the listing from standard input.
 - `DEST_DIR` is the directory where you want to recreate the structure
 
 ### Options
@@ -40,6 +41,8 @@ Where:
 ```
 -d, --dry-run   Don't touch the filesystem—just report what would be done
 -v, --verbose   Print each path as it is (or would be) created
+    --force     Overwrite existing files when recreating the hierarchy
+-V, --version   Show program's version number and exit
 -h, --help      Show help message and exit
 ```
 
@@ -67,6 +70,24 @@ tree /path/to/source > directory_structure.txt
 
 ```bash
 ./transplant directory_structure.txt /path/to/destination --verbose
+```
+
+5. Read the listing from standard input:
+
+```bash
+tree /path/to/source | ./transplant - /path/to/destination
+```
+
+6. Overwrite existing files when recreating the structure:
+
+```bash
+./transplant directory_structure.txt /path/to/destination --force
+```
+
+7. Display the script version:
+
+```bash
+./transplant --version
 ```
 
 ## License

--- a/transplant
+++ b/transplant
@@ -1,11 +1,19 @@
 #!/usr/bin/env python3
 
-"""transplant - Recreate directory structures from `tree`'s output"""
+"""transplant - Recreate directory structures from `tree`'s output.
+
+Features include:
+* Accepting ``-`` as ``TREE_OUTPUT`` to read from standard input.
+* ``--version`` flag to report the program version.
+* ``--force`` option to overwrite existing files when recreating the hierarchy.
+"""
 
 import argparse
 from pathlib import Path
 import re
 import sys
+
+__version__ = "0.1.0"
 
 
 LINE_RE = re.compile(r"^(?P<prefix>(?:│   |    )*)(?P<fork>[├└])── (?P<name>.+)$")
@@ -21,8 +29,7 @@ def parse_args(args):
     argp.add_argument(
         "listing",
         metavar="TREE_OUTPUT",
-        type=Path,
-        help="Text file containing the output of `tree`.",
+        help="Text file containing the output of `tree` or '-' for STDIN.",
     )
 
     argp.add_argument(
@@ -47,6 +54,20 @@ def parse_args(args):
         help="Print each path as it is (or would be) created.",
     )
 
+    argp.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing files when recreating the hierarchy.",
+    )
+
+    argp.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+        help="Show program's version number and exit.",
+    )
+
     parsed = argp.parse_args(args)
     if not parsed.dry_run and parsed.destination is None:
         argp.error(
@@ -60,9 +81,14 @@ def is_probably_file(fname):
     return "." in fname.strip(".") and not fname.endswith("/")
 
 
-def rebuild_tree(listing_path, destination, dry_run=False, verbose=False):
-    if not listing_path.exists():
-        sys.exit(f"Listing file not found: {listing_path}")
+def rebuild_tree(listing_path, destination, dry_run=False, verbose=False, force=False):
+    if listing_path == "-":
+        fh = sys.stdin
+    else:
+        listing_path = Path(listing_path)
+        if not listing_path.exists():
+            sys.exit(f"Listing file not found: {listing_path}")
+        fh = listing_path.open("r", encoding="utf-8")
 
     if dry_run:
         verbose = True
@@ -74,41 +100,49 @@ def rebuild_tree(listing_path, destination, dry_run=False, verbose=False):
 
     stack = [destination]
 
-    with listing_path.open("r", encoding="utf-8") as fh:
-        for raw in fh:
-            line = raw.rstrip("\n")
-            if verbose:
-                print(line)
+    for raw in fh:
+        line = raw.rstrip("\n")
+        if verbose:
+            print(line)
 
-            if line.strip() == "." or SUMMARY_RE.match(line):
-                continue
+        if line.strip() == "." or SUMMARY_RE.match(line):
+            continue
 
-            m = LINE_RE.match(line)
-            if not m:
+        m = LINE_RE.match(line)
+        if not m:
                 if verbose:
                     print("failed to match line format, skipping...")
                 continue
 
-            depth = len(m.group("prefix")) // 4 + 1
-            name = m.group("name").rstrip("/")
-            if verbose:
+        depth = len(m.group("prefix")) // 4 + 1
+        name = m.group("name").rstrip("/")
+        if verbose:
                 print(f"Depth: {depth}, Name: {name}")
 
-            stack = stack[:depth]
-            parent_dir = stack[-1]
-            target = parent_dir / name
-            if verbose:
+        stack = stack[:depth]
+        parent_dir = stack[-1]
+        target = parent_dir / name
+        if verbose:
                 print(f"parent: {parent_dir}")
                 print(f"CREATE {target}")
 
-            if is_probably_file(name):
+        if is_probably_file(name):
                 if not dry_run:
                     target.parent.mkdir(parents=True, exist_ok=True)
-                    target.touch(exist_ok=True)
-            else:
+                    if force:
+                        with target.open("w", encoding="utf-8"):
+                            pass
+                    else:
+                        target.touch(exist_ok=True)
+        else:
                 if not dry_run:
+                    if force and target.exists() and target.is_file():
+                        target.unlink()
                     target.mkdir(parents=True, exist_ok=True)
                 stack.append(target)
+
+    if fh is not sys.stdin:
+        fh.close()
 
     print(f"Directory structure transplanted to {destination.resolve()}")
 
@@ -121,6 +155,7 @@ def main(args):
         destination=params.destination,
         dry_run=params.dry_run,
         verbose=params.verbose,
+        force=params.force,
     )
 
 


### PR DESCRIPTION
## Summary
- add `--version` flag and version constant
- accept `-` as `TREE_OUTPUT` for stdin
- add `--force` option for overwriting existing files
- document new options in README
- update module docstring to describe features

## Testing
- `python3 -m py_compile transplant`
- `python3 transplant sample.tree test_out --dry-run --verbose | head -n 20`
- `cat sample.tree | python3 transplant - test_out --dry-run | head -n 5`
- `python3 transplant sample.tree outdir --force > /tmp/translog.txt && tail -n 3 /tmp/translog.txt`
- `python3 transplant --version`


------
https://chatgpt.com/codex/tasks/task_e_684202270d3c8328933ebf272d432012